### PR TITLE
Extract models from core

### DIFF
--- a/bin/cluster/velox_config.py
+++ b/bin/cluster/velox_config.py
@@ -2,22 +2,25 @@ import json
 
 matrixfact_config = {
         'onlineUpdateDelayInMillis': 5000,
-        'batchRetrainDelayInMillis': 500000,
-        'dimensions': 50,
-        'modelType': 'MatrixFactorizationModel',
+        'batchRetrainDelayInMillis': 50000000,
+        'config': {
+                'numFeatures': 50
+                },
+        'modelType': 'edu.berkeley.veloxms.examples.MatrixFactorizationModel',
         }
 
 newsgroups_config = {
         'onlineUpdateDelayInMillis': 5000,
         'batchRetrainDelayInMillis': 50000000,
-        'dimensions': 20,
-        'trainPath': 's3n://20newsgroups/',
-        'modelType': 'NewsgroupsModel',
+        'config': {
+                'dataPath': 's3n://20newsgroups/',
+                },
+        'modelType': 'edu.berkeley.veloxms.examples.NewsgroupsModel',
         }
 
 config = {
         'sparkMaster': "local[2]",
-        'sparkDataLocation': "/Users/tomerk11/Desktop/velox-data",
+        'sparkDataLocation': "/Users/crankshaw/Desktop/velox-data",
         'models': {
                 'matrixfact': json.dumps(matrixfact_config),
                 'newsgroups': json.dumps(newsgroups_config)

--- a/bin/cluster/velox_deploy.py
+++ b/bin/cluster/velox_deploy.py
@@ -181,7 +181,6 @@ def is_ssh_available():
 @task
 def launch_ec2_cluster(cluster_name,
                        cluster_size,
-                       localkey,
                        keyname, # name of AWS key pair
                        spot_price=None,
                        instance_type='r3.2xlarge',
@@ -289,11 +288,9 @@ def launch_ec2_cluster(cluster_name,
 
     set_hostnames()
 
-    ####### TODO remove once Velox is open source
-    execute(upload_deploy_key, localkey, role='servers')
     puts("Building Velox")
     execute(build_velox,
-            git_remote="git@github.com:amplab/velox-modelserver.git",
+            git_remote="https://github.com/amplab/velox-modelserver.git",
             branch="develop",
             role='servers')
 
@@ -324,7 +321,7 @@ def install_velox_local(etcd_loc):
         abort("{pl} is unsupported".format(pl=sys.platform))
     with lcd(velox_root_dir + "/lib"):
         local("rm -rf keystone")
-        local("git clone git@github.com:amplab/keystone.git")
+        local("git clone https://github.com/amplab/keystone.git")
     with lcd(velox_root_dir + "/lib/keystone"):
         local("sbt/sbt publish-m2")
     with lcd(velox_root_dir):
@@ -382,7 +379,7 @@ def build_velox(git_remote, branch):
             run("git checkout -b veloxbranch vremote/%s" % branch)
             run("git reset --hard vremote/%s" % branch)
         with cd("~/velox-modelserver/lib"):
-            run("git clone git@github.com:amplab/keystone.git")
+            run("git clone https://github.com/amplab/keystone.git")
         with cd("~/velox-modelserver/lib/keystone"):
             run("sbt/sbt publish-m2")
         with cd("~/velox-modelserver"):

--- a/docs/deployment_guide.md
+++ b/docs/deployment_guide.md
@@ -37,13 +37,12 @@ export VELOX_CLUSTER_KEY=~/.ssh/my_key_pair.pem
 ```
 
 ####Launch a cluster
-+ `fab launch_ec2_cluster:cluster_name=my-application,cluster_size=3,localkey=my_github_ssh_key,keyname=my_aws_keypair` to launch a cluster. The default is to launch reserved instances. If you
++ `fab launch_ec2_cluster:cluster_name=my-application,cluster_size=3,keyname=my_aws_keypair` to launch a cluster. The default is to launch reserved instances. If you
 would like to launch spot instances instead, specify the `spot_price` as an additional argument
 to the launch command.
 + edit `velox_config.py` to configure your Velox deployment (see [Configuration](#secconfig) for details).
 + `fab start_velox` to start the cluster
 
-__TODO__ remove localkey once Velox is open-sourced
 
 ####Using your own cluster
 If you'd like to launch a cluster some other way, you can still use the `velox_deploy.py` script

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
 
   <modules>
     <module>veloxms-core</module>
+    <module>veloxms-examples</module>
   </modules>
 
   <properties>

--- a/veloxms-core/src/main/scala/edu/berkeley/veloxms/VeloxApplication.scala
+++ b/veloxms-core/src/main/scala/edu/berkeley/veloxms/VeloxApplication.scala
@@ -118,6 +118,15 @@ class VeloxApplication extends Application[VeloxConfiguration] with Logging {
     } else {
       None
     }
+
+    // This section on reflection is adapted from the example in
+    // http://docs.scala-lang.org/overviews/reflection/overview.html
+    // It automatically calls the constructor for the concrete subclass
+    // of Model provided in the configuration. The only restriction here
+    // is that the model constructor must have the same exact
+    // three arguments as Model. Subclass specific configuration can be provided
+    // in the model configuration as additional json that will be passed
+    // directly to the instance.
     val mirror = ru.runtimeMirror(getClass.getClassLoader)
     val clz = Class.forName(modelType)
     val classSymbol = mirror.classSymbol(clz)

--- a/veloxms-core/src/main/scala/edu/berkeley/veloxms/VeloxApplication.scala
+++ b/veloxms-core/src/main/scala/edu/berkeley/veloxms/VeloxApplication.scala
@@ -16,6 +16,8 @@ import org.eclipse.jetty.servlet.ServletHolder
 
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
+import scala.reflect.runtime.{universe => ru}
+import com.fasterxml.jackson.databind.JsonNode
 
 class VeloxConfiguration extends Configuration {
   val hostname: String = "none"
@@ -92,9 +94,53 @@ class VeloxApplication extends Application[VeloxConfiguration] with Logging {
     jsonMapper.readValue(json, classOf[Seq[String]])
   }
 
+  def createModel(name: String,
+                  sparkContext: SparkContext,
+                  etcdClient: EtcdClient,
+                  broadcastProvider: BroadcastProvider,
+                  sparkDataLocation: String,
+                  partitionMap: Seq[String],
+                  env: Environment,
+                  hostname: String
+                  ): Unit = {
 
-  def registerModelResources[T : ClassTag](
-      model: Model[T],
+    val key = s"$configEtcdPath/models/$name"
+    val json = etcdClient.getValue(key)
+    val jsonTree = jsonMapper.readTree(json)
+    require(jsonTree.has("modelType"))
+    require(jsonTree.has("onlineUpdateDelayInMillis"))
+    require(jsonTree.has("batchRetrainDelayInMillis"))
+    val modelType = jsonTree.get("modelType").asText
+    val onlineUpdateDelay = jsonTree.get("onlineUpdateDelayInMillis").asLong
+    val batchRetrainDelay = jsonTree.get("batchRetrainDelayInMillis").asLong
+    val modelSpecificConfig: Option[JsonNode] = if (jsonTree.has("config")) {
+      Some(jsonTree.get("config"))
+    } else {
+      None
+    }
+    val mirror = ru.runtimeMirror(getClass.getClassLoader)
+    val clz = Class.forName(modelType)
+    val classSymbol = mirror.classSymbol(clz)
+    val cm = mirror.reflectClass(classSymbol)
+    val constructor = classSymbol.toType.declaration(ru.nme.CONSTRUCTOR).asMethod
+    val ctorm = cm.reflectConstructor(constructor)
+    val model = ctorm(name, broadcastProvider, modelSpecificConfig).asInstanceOf[Model[_]]
+    registerModelResources(
+      model,
+      name,
+      onlineUpdateDelay,
+      batchRetrainDelay,
+      sparkContext,
+      etcdClient,
+      broadcastProvider,
+      sparkDataLocation,
+      partitionMap,
+      env,
+      hostname)
+  }
+
+  def registerModelResources(
+      model: Model[_],
       name: String,
       onlineUpdateDelayInMillis: Long,
       batchRetrainDelayInMillis: Long,
@@ -190,72 +236,5 @@ class VeloxApplication extends Application[VeloxConfiguration] with Logging {
     env.getApplicationContext.addServlet(new ServletHolder(loadObservationsServlet), "/loadobservations/" + name)
   }
 
-  def createModel(name: String,
-                  sparkContext: SparkContext,
-                  etcdClient: EtcdClient,
-                  broadcastProvider: BroadcastProvider,
-                  sparkDataLocation: String,
-                  partitionMap: Seq[String],
-                  env: Environment,
-                  hostname: String
-                  ): Unit = {
-
-    val key = s"$configEtcdPath/models/$name"
-    val json = etcdClient.getValue(key)
-    val modelConfig = jsonMapper.readValue(json, classOf[VeloxModelConfig])
-
-    // TODO(crankshaw) cleanup model constructor code after Tomer
-    // finishes refactoring model and storage configuration
-    val averageUser = Array.fill[Double](modelConfig.dimensions)(1.0)
-    modelConfig.modelType match {
-      case "MatrixFactorizationModel" =>
-        val model = new MatrixFactorizationModel(
-          name,
-          broadcastProvider,
-          modelConfig.dimensions,
-          averageUser)
-        registerModelResources(
-          model,
-          name,
-          modelConfig.onlineUpdateDelayInMillis,
-          modelConfig.batchRetrainDelayInMillis,
-          sparkContext,
-          etcdClient,
-          broadcastProvider,
-          sparkDataLocation,
-          partitionMap,
-          env,
-          hostname)
-      case "NewsgroupsModel" =>
-        val model = new NewsgroupsModel(
-          name,
-          broadcastProvider,
-          averageUser,
-          modelConfig.trainPath.get)
-        registerModelResources(
-          model,
-          name,
-          modelConfig.onlineUpdateDelayInMillis,
-          modelConfig.batchRetrainDelayInMillis,
-          sparkContext,
-          etcdClient,
-          broadcastProvider,
-          sparkDataLocation,
-          partitionMap,
-          env,
-          hostname)
-    }
-  }
 }
-
-case class VeloxModelConfig(
-  dimensions: Int,
-  modelType: String,
-  trainPath: Option[String],
-  onlineUpdateDelayInMillis: Long,
-  batchRetrainDelayInMillis: Long
-)
-
-
-
 

--- a/veloxms-core/src/main/scala/edu/berkeley/veloxms/background/BatchRetrainManager.scala
+++ b/veloxms-core/src/main/scala/edu/berkeley/veloxms/background/BatchRetrainManager.scala
@@ -85,7 +85,8 @@ class BatchRetrainManager[T](
         logInfo(s"Write to spark cluster responses: ${writeResponses.mkString("\n")}")
 
         // Do the core batch retrain on spark
-        val trainingData: RDD[(UserID, T, Double)] = sparkContext.objectFile(s"$sparkDataLocation/${obsDataLocation.loc}/*/*")
+        val trainingData: RDD[(UserID, T, Double)] = sparkContext.objectFile(s"${obsDataLocation.loc}/*/*")
+
         val itemFeatures = model.retrainFeatureModelsInSpark(trainingData, nextVersion)
         val userWeights = model.retrainUserWeightsInSpark(itemFeatures, trainingData).map {
           case (userId, weights) => s"$userId, ${weights.mkString(", ")}"

--- a/veloxms-core/src/main/scala/edu/berkeley/veloxms/background/BatchRetrainManager.scala
+++ b/veloxms-core/src/main/scala/edu/berkeley/veloxms/background/BatchRetrainManager.scala
@@ -88,7 +88,7 @@ class BatchRetrainManager[T](
         val trainingData: RDD[(UserID, T, Double)] = sparkContext.objectFile(s"${obsDataLocation.loc}/*/*")
 
         val itemFeatures = model.retrainFeatureModelsInSpark(trainingData, nextVersion)
-        val userWeights = model.retrainUserWeightsInSpark(itemFeatures, trainingData).map {
+        val userWeights = model.retrainUserWeightsInSpark(itemFeatures, trainingData, nextVersion).map {
           case (userId, weights) => s"$userId, ${weights.mkString(", ")}"
         }
 

--- a/veloxms-core/src/main/scala/edu/berkeley/veloxms/background/OnlineUpdateManager.scala
+++ b/veloxms-core/src/main/scala/edu/berkeley/veloxms/background/OnlineUpdateManager.scala
@@ -9,7 +9,13 @@ import edu.berkeley.veloxms.models.Model
 
 import scala.collection.mutable
 
-class OnlineUpdateManager[T](model: Model[T], delay: Long, unit: TimeUnit, timer: Timer) extends BackgroundTask(delay, unit) {
+class OnlineUpdateManager[T](
+    val model: Model[T],
+    val delay: Long,
+    val unit: TimeUnit,
+    val timer: Timer)
+  extends BackgroundTask(delay, unit) {
+
   private val onlineUpdatesEnabled: AtomicBoolean = new AtomicBoolean(true)
   private val observations = new ConcurrentLinkedQueue[(UserID, T, Double)]()
 

--- a/veloxms-core/src/main/scala/edu/berkeley/veloxms/models/KeystoneModel.scala
+++ b/veloxms-core/src/main/scala/edu/berkeley/veloxms/models/KeystoneModel.scala
@@ -4,13 +4,19 @@ import edu.berkeley.veloxms.{UserID, Version, FeatureVector}
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import pipelines.Transformer
+import com.fasterxml.jackson.databind.JsonNode
+import edu.berkeley.veloxms.storage.BroadcastProvider
 
 import scala.reflect.ClassTag
 
 /**
  * A model that uses a Keystone [[Transformer]] to featurize the context
  */
-abstract class KeystoneModel[T : ClassTag] extends Model[T] {
+abstract class KeystoneModel[T : ClassTag](
+    override val modelName: String,
+    override val broadcastProvider: BroadcastProvider,
+    override val jsonConfig: Option[JsonNode])
+  extends Model[T](modelName, broadcastProvider, jsonConfig) {
   private val modelBroadcast = broadcast[Transformer[T, FeatureVector]]("model")
 
   override def computeFeatures(data: T, version: Version): FeatureVector = {

--- a/veloxms-core/src/main/scala/edu/berkeley/veloxms/models/Model.scala
+++ b/veloxms-core/src/main/scala/edu/berkeley/veloxms/models/Model.scala
@@ -61,7 +61,6 @@ abstract class Model[T: ClassTag](
 
   /** Average user weight vector.
    * Used for warmstart for new users
-   * TODO: SHOULD BE RETRAINED WHEN BULK RETRAINING!!!
    **/
   val averageUser = broadcast[WeightVector]("avg_user")
 

--- a/veloxms-core/src/main/scala/edu/berkeley/veloxms/package.scala
+++ b/veloxms-core/src/main/scala/edu/berkeley/veloxms/package.scala
@@ -15,6 +15,8 @@ package object veloxms {
 
   // TODO: Probably shouldn't be in the package object
   val jsonMapper = new ObjectMapper().registerModule(new DefaultScalaModule)
-  def fromJson[T : ClassTag](node: JsonNode): T = jsonMapper.treeToValue(node, classTag[T].runtimeClass.asInstanceOf[Class[T]])
+  def fromJson[T : ClassTag](node: JsonNode): T = {
+    jsonMapper.treeToValue(node, classTag[T].runtimeClass.asInstanceOf[Class[T]])
+  }
 
 }

--- a/veloxms-core/src/main/scala/edu/berkeley/veloxms/resources/AddObservationServlet.scala
+++ b/veloxms-core/src/main/scala/edu/berkeley/veloxms/resources/AddObservationServlet.scala
@@ -6,6 +6,7 @@ import javax.servlet.http.{HttpServlet, HttpServletRequest, HttpServletResponse}
 import com.codahale.metrics.Timer
 import dispatch._
 import edu.berkeley.veloxms._
+import edu.berkeley.veloxms.models.Model
 import edu.berkeley.veloxms.background.OnlineUpdateManager
 import edu.berkeley.veloxms.util.{Utils, Logging}
 
@@ -14,7 +15,7 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.reflect._
 
-class AddObservationServlet[T : ClassTag](
+class AddObservationServlet[T](
     onlineUpdateManager: OnlineUpdateManager[T],
     timer: Timer,
     modelName: String,
@@ -39,7 +40,7 @@ class AddObservationServlet[T : ClassTag](
 
       val correctPartition = Utils.nonNegativeMod(uid.hashCode(), partitionMap.size)
       val output = if (partitionMap(correctPartition) == hostname) {
-        val item: T = fromJson(context)
+        val item: T = onlineUpdateManager.model.jsonToInput(context)
         onlineUpdateManager.addObservation(uid, item, score)
         "Successfully added observation"
       } else {

--- a/veloxms-core/src/main/scala/edu/berkeley/veloxms/resources/PointPredictionServlet.scala
+++ b/veloxms-core/src/main/scala/edu/berkeley/veloxms/resources/PointPredictionServlet.scala
@@ -46,7 +46,6 @@ class PointPredictionServlet[T](
       val output = if (partitionMap(correctPartition) == hostname) {
         // val item: T = fromJson[T](context)
         val item: T = model.jsonToInput(context)
-        println(item.getClass)
         model.predict(uid, item, model.currentVersion)
       } else {
         val h = hosts(correctPartition)
@@ -55,6 +54,7 @@ class PointPredictionServlet[T](
         val httpReq = http(forwardedReq OK as.String)
         Await.result(httpReq, Duration(3000, TimeUnit.MILLISECONDS))
       }
+
 
       resp.setContentType("application/json")
       jsonMapper.writeValue(resp.getOutputStream, output)

--- a/veloxms-core/src/main/scala/edu/berkeley/veloxms/resources/PointPredictionServlet.scala
+++ b/veloxms-core/src/main/scala/edu/berkeley/veloxms/resources/PointPredictionServlet.scala
@@ -21,7 +21,7 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.reflect._
 
-class PointPredictionServlet[T : ClassTag](
+class PointPredictionServlet[T](
     model: Model[T],
     timer: Timer,
     partitionMap: Seq[String],
@@ -44,7 +44,9 @@ class PointPredictionServlet[T : ClassTag](
 
       val correctPartition = Utils.nonNegativeMod(uid.hashCode(), partitionMap.size)
       val output = if (partitionMap(correctPartition) == hostname) {
-        val item: T = fromJson(context)
+        // val item: T = fromJson[T](context)
+        val item: T = model.jsonToInput(context)
+        println(item.getClass)
         model.predict(uid, item, model.currentVersion)
       } else {
         val h = hosts(correctPartition)

--- a/veloxms-core/src/main/scala/edu/berkeley/veloxms/resources/TopKPredictionServlet.scala
+++ b/veloxms-core/src/main/scala/edu/berkeley/veloxms/resources/TopKPredictionServlet.scala
@@ -15,7 +15,7 @@ import edu.berkeley.veloxms.util.Utils
 import scala.concurrent.duration.Duration
 import scala.reflect._
 
-class TopKPredictionServlet[T : ClassTag](
+class TopKPredictionServlet[T](
     model: Model[T],
     timer: Timer,
     partitionMap: Seq[String],
@@ -42,7 +42,7 @@ class TopKPredictionServlet[T : ClassTag](
         val k: Int = input.get("k").asInt()
         val context = input.get("context")
 
-        val candidateSet: Array[T] = fromJson[Array[T]](context)
+        val candidateSet: Array[T] = model.jsonArrayToInput(context)
         model.predictTopK(uid, k, candidateSet, model.currentVersion)
       } else {
         val h = hosts(correctPartition)

--- a/veloxms-examples/pom.xml
+++ b/veloxms-examples/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>edu.berkeley.veloxms</groupId>
+    <artifactId>velox-parent</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>veloxms-examples</artifactId>
+  <name>Velox Example Models</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>edu.berkeley.veloxms</groupId>
+      <artifactId>veloxms-core</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_${scala.binary.version}</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>edu.berkeley.cs.amplab</groupId>
+      <artifactId>keystone_2.10</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-mllib_${scala.binary.version}</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.scalatest</groupId>
+      <artifactId>scalatest_${scala.binary.version}</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.scalamock</groupId>
+      <artifactId>scalamock-scalatest-support_${scala.binary.version}</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scalap</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
+    <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
+    <plugins>
+      <plugin>
+        <groupId>org.scalatest</groupId>
+        <artifactId>scalatest-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.3</version>
+        <configuration>
+          <relocations>
+            <relocation>
+              <pattern>org.eclipse.jetty</pattern>
+              <shadedPattern>edu.berkeley.veloxms.jetty</shadedPattern>
+            </relocation>
+          </relocations>
+          <createDependencyReducedPom>true</createDependencyReducedPom>
+          <!-- <minimizeJar>true</minimizeJar> -->
+          <!-- <promoteTransitiveDependencies>true</promoteTransitiveDependencies> -->
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>META-INF/*.SF</exclude>
+                <exclude>META-INF/*.DSA</exclude>
+              </excludes>
+            </filter>
+          </filters>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <!-- <mainClass>edu.berkeley.veloxms.VeloxApplication</mainClass> -->
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                  <resource>reference.conf</resource>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/veloxms-examples/src/main/scala/edu/berkeley/veloxms/examples/NewsgroupsModel.scala
+++ b/veloxms-examples/src/main/scala/edu/berkeley/veloxms/examples/NewsgroupsModel.scala
@@ -1,8 +1,9 @@
-package edu.berkeley.veloxms.models
+package edu.berkeley.veloxms.examples
 
 import breeze.linalg.{Vector, normalize}
 import breeze.numerics.exp
 import edu.berkeley.veloxms._
+import edu.berkeley.veloxms.models._
 import edu.berkeley.veloxms.storage.BroadcastProvider
 import loaders.{LabeledData, NewsgroupsDataLoader}
 import nodes.learning.NaiveBayesEstimator
@@ -12,14 +13,17 @@ import nodes.util.CommonSparseFeatures
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.{UnionRDD, RDD}
 import pipelines.Transformer
+import com.fasterxml.jackson.databind.JsonNode
 
+case class NewsConfig(dataPath: String)
 
 class NewsgroupsModel(
-    val modelName: String,
-    val broadcastProvider: BroadcastProvider,
-    val averageUser: WeightVector,
-    val trainPath: String
-  ) extends KeystoneModel[String] {
+    override val modelName: String,
+    override val broadcastProvider: BroadcastProvider,
+    override val jsonConfig: Option[JsonNode])
+  extends KeystoneModel[String](modelName, broadcastProvider, jsonConfig) {
+
+  val trainPath = fromJson[NewsConfig](jsonConfig.get).dataPath
 
   val numFeatures = NewsgroupsDataLoader.classes.length
   def fit(sc: SparkContext): Transformer[String, FeatureVector] = {
@@ -41,3 +45,5 @@ class NewsgroupsModel(
     predictor.thenFunction(_.toArray)
   }
 }
+
+


### PR DESCRIPTION
This pull request implements a few things:
- Removes the need to edit `VeloxApplication.scala` when implementing a new feature model type (#75). Now, as long as the model implementation is on the classpath, Velox will use reflection to create the model instance. This means that `veloxms-core` can be used as a dependency to applications that want to use Velox to serve models, rather than having to rebuild the package.
- Moves the existing concrete feature model implementations to a separate module called `veloxms-examples`.
- Makes the average or "warm-start" user model a broadcast variable that is automatically retrained when doing batch training. It is trained by averaging the labels of the training data across all users and using that as the training dataset (#47).
- Allows you to specify a specific KeystoneML git commit to build against.
