### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-##Velox Model Server
+## Velox Model Server
 
 <!---[![Build Status](https://amplab.cs.berkeley.edu/jenkins/buildStatus/icon?job=velox testing)](https://amplab.cs.berkeley.edu/jenkins/job/velox%20testing/)-->
 
-#VELOX
+# VELOX
 
 Velox is a system for serving machine learning predictions.
 
@@ -13,7 +13,7 @@ Velox is a system for serving machine learning predictions.
 ![Velox In BDAS](docs/missing_piece.png)
 
 
-##Quickstart
+## Quickstart
 
 Installing Velox using the provided scripts requires [`fabric`](http://www.fabfile.org/installing.html) >= 1.10.0 and dependencies (Paramiko >= 1.10.0)
 
@@ -39,7 +39,7 @@ curl http://localhost:8080/retrain/matrixfact
 
 For more details and a guide to deploying Velox on a cluster, check out our [deployment guide](docs/deployment_guide.md).
 
-##Contact
+## Contact
 
 + Mailing list: velox-modelserver@googlegroups.com
 + crankshaw@cs.berkeley.edu
@@ -55,7 +55,7 @@ If you'd like to contribute code, please submit Github Pull Request for review a
 + [Tech talk](http://www.slideshare.net/dscrankshaw/velox-at-sf-data-mining-meetup)
 + [Video](https://www.youtube.com/watch?v=rESINg9lfGY) and [slides](http://www.slideshare.net/dscrankshaw/veloxampcamp5-final) from presentation at AMPCamp 5
 
-##License
+## License
 
 Velox is under the Apache 2.0 [License](LICENSE).
 

--- a/docs/deployment_guide.md
+++ b/docs/deployment_guide.md
@@ -1,7 +1,7 @@
-##Velox Deployment Guide
+## Velox Deployment Guide
 
 
-###Running Velox Locally
+### Running Velox Locally
 1. `git clone https://github.com/amplab/velox-modelserver.git; cd velox-modelserver`
 1. `cd bin/cluster`
 1. edit `velox_config.py` to configure your Velox deployment (see [Configuration](#secconfig) for details).


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
